### PR TITLE
Fix buildout.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     zip_safe=False,
 
     install_requires=[
-        'ftw.simplelayout',
+        'ftw.simplelayout [contenttypes]',
         'ftw.slider',
         'setuptools',
         'plone.dexterity',


### PR DESCRIPTION
With the latest "ftw.simplelayout" version the content types are now available through the extras "contenttypes".
