### PR TITLE
Hide message about missing slider panes for anonymous users.

### DIFF
--- a/ftw/sliderblock/browser/sliderblock.py
+++ b/ftw/sliderblock/browser/sliderblock.py
@@ -1,3 +1,5 @@
+from Acquisition._Acquisition import aq_inner
+from Products.CMFCore.utils import getToolByName
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
@@ -14,3 +16,10 @@ class SliderBlockView(BaseBlock):
              "}});"
         return js.format(uid=self.context.UID(),
                          config=self.context.slick_config)
+
+    def can_add(self):
+        context = aq_inner(self.context)
+        mtool = getToolByName(context, 'portal_membership')
+        permission = mtool.checkPermission('ftw.sliderblock: Add SliderBlock',
+                                           context)
+        return bool(permission)

--- a/ftw/sliderblock/browser/templates/sliderblock.pt
+++ b/ftw/sliderblock/browser/templates/sliderblock.pt
@@ -11,7 +11,7 @@
         <script type="text/javascript" tal:content="view/get_slick_config"
                 tal:condition="panes"/>
 
-        <div tal:condition="not:panes"
+        <div tal:condition="python: view.can_add() and not panes"
              tal:define="folder_contents_url string:${context/absolute_url}/folder_contents;"
              i18n:translate="empty_sliderblock_label">This SliderBlock is empty. Please add some SliderPanes through <tal:href i18n:name="folder_contents_url" tal:content="folder_contents_url"></tal:href>.</div>
         <div tal:condition="panes"


### PR DESCRIPTION
The message is only rendered if the user has the corresponding permission.
