### PR TITLE
Initialize slick twice causes doubled play/pause buttons.

### DIFF
--- a/ftw/sliderblock/browser/resources/sliderblock.js
+++ b/ftw/sliderblock/browser/resources/sliderblock.js
@@ -1,5 +1,5 @@
-$(document).on('onBeforeClose', '.overlay', function(){
-  ftwSliderInit();
+$(document).on("overlaySubmit", ".overlay", function(){
+  ftwSliderUpdate();
 });
 
 $(document).on('sortstop', '.sl-column', function(){


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/204

Due to https://github.com/4teamwork/bern.web/issues/204 initializing
slick twice causes doubled play/pause buttons. So listen to
overlaySubmit event instead of closed. The slider should only get
updated after a successfully reload of the slider content.

Depends on https://github.com/4teamwork/ftw.simplelayout/pull/179, https://github.com/4teamwork/ftw.slider/pull/34
