### PR TITLE
Enable IReferenceable on all types.

### DIFF
--- a/ftw/sliderblock/profiles/default/types/ftw.sliderblock.SliderBlock.xml
+++ b/ftw/sliderblock/profiles/default/types/ftw.sliderblock.SliderBlock.xml
@@ -28,6 +28,7 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->


### PR DESCRIPTION
The IReferenceable behavior adds the objects to the reference catalog.
We need this in order to lookup objects by UUID.
