### PR TITLE
After moving or edition a block the slider gets initialized twice.

### DIFF
--- a/ftw/sliderblock/browser/resources/sliderblock.js
+++ b/ftw/sliderblock/browser/resources/sliderblock.js
@@ -2,6 +2,6 @@ $(document).on("overlaySubmit", ".overlay", function(){
   ftwSliderUpdate();
 });
 
-$(document).on('sortstop', '.sl-column', function(){
-  ftwSliderInit();
+$(document).on("sortstop", ".sl-column", function(){
+  ftwSliderUpdate();
 });


### PR DESCRIPTION
Just update the not initialized block.

What happened when a block has been moved.

In 943d25cdd2c815d481660f52f93beba03020e91f this was already done for submitted event.

![bildschirmfoto 2015-07-21 um 09 52 04](https://cloud.githubusercontent.com/assets/1637820/8795574/6e8a9bc6-2f8e-11e5-8340-84d70d76c1a5.png)
