### PR TITLE
render image scales in cachable form.

### DIFF
--- a/ftw/sliderblock/browser/templates/sliderblock.pt
+++ b/ftw/sliderblock/browser/templates/sliderblock.pt
@@ -22,7 +22,8 @@
                            tal:attributes="href link;
                                            title pane/Description">
                             <div class="sliderImage"
-                                 tal:content="structure pane/@@images/image" />
+                                 tal:define="images pane/@@images"
+                                 tal:content="structure python:images.tag()" />
                             <div class="sliderText"
                                  tal:condition="pane/text">
                                 <p tal:condition="pane/title"


### PR DESCRIPTION
By not using the fieldname but using the .tag() method of the images view, the primary field is used with a UID in the URL.
This enables caching of the image since the URL now is unique and will change when the image changes.
`plone.namedfile >= 2.0.8` is required for the caching to work.
