### PR TITLE
Sliderblock is not updated after edit action.

### DIFF
--- a/ftw/sliderblock/browser/resources/sliderblock.js
+++ b/ftw/sliderblock/browser/resources/sliderblock.js
@@ -22,7 +22,7 @@
 
     sliders.init();
 
-    $(document).on("overlaySubmit", ".overlay", function() { sliders.update(); });
+    $(document).on("blockContentReplaced", function() { sliders.update(); });
 
     $(document).on("sortstop", ".sl-column", function() { sliders.update(); });
 


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/492 with https://github.com/4teamwork/bern.web/pull/498

Depends on https://github.com/4teamwork/ftw.simplelayout/pull/228

Due to https://github.com/4teamwork/ftw.simplelayout/pull/223 the
animation for the overlays has been removed. So the submitevent is
triggered earlier.
