### PR TITLE
According to access4all the slider block has accessibility issues.

### DIFF
--- a/ftw/sliderblock/browser/templates/sliderblock.pt
+++ b/ftw/sliderblock/browser/templates/sliderblock.pt
@@ -22,13 +22,19 @@
                            tal:attributes="href link;
                                            title pane/Description">
                             <div class="sliderImage"
-                                 tal:define="images pane/@@images"
-                                 tal:content="structure python:images.tag()" />
+                                 tal:define="images pane/@@images">
+                                 <img tal:define="scales pane/@@images;
+                                                  thumbnail python: scales.scale('image');"
+                                       tal:attributes="src thumbnail/url;
+                                                       width thumbnail/width;
+                                                       height thumbnail/height;
+                                                       alt python: '' if link else pane.Description()"/>
+                            </div>
                             <div class="sliderText"
                                  tal:condition="pane/text">
                                 <p tal:condition="pane/title"
                                    tal:content="pane/title"
-                                   class="documentFirstHeading title"/>
+                                   tal:attributes="class python: 'documentFirstHeading title external-link' if pane.external_url else 'documentFirstHeading title'"/>
                                 <span tal:replace="structure pane/text/output"/>
                             </div>
                         </a>


### PR DESCRIPTION
- Make empty alt-text if image is in a link tag.
- Display external-link indicator.
