### PR TITLE
Remove title from link and add alttext to image

### DIFF
--- a/ftw/sliderblock/browser/templates/sliderblock.pt
+++ b/ftw/sliderblock/browser/templates/sliderblock.pt
@@ -19,8 +19,7 @@
                     <tal:pane tal:define="internal_link string:${portal/absolute_url}${pane/link};
                                           link python: pane.link and internal_link or pane.external_url;">
                         <a tal:omit-tag="not:link"
-                           tal:attributes="href link;
-                                           title pane/Description">
+                           tal:attributes="href link;">
                             <div class="sliderImage"
                                  tal:define="images pane/@@images">
                                  <img tal:define="scales pane/@@images;
@@ -28,7 +27,7 @@
                                        tal:attributes="src thumbnail/url;
                                                        width thumbnail/width;
                                                        height thumbnail/height;
-                                                       alt python: '' if link else pane.Description()"/>
+                                                       alt pane/Description"/>
                             </div>
                             <div class="sliderText"
                                  tal:condition="pane/text">


### PR DESCRIPTION
@maethu 

The implementation was like this:
- Add the description of a pane as image alt-text if no link exists
- Add no image alt-text if a link exists.
- Add pane-description as link-title if a link exists 

The new implementation is:
- Add no title attribute on the link
- Add always the pane-description as alt-text to the image-tag

Why?
- Accessibility reasons.

If we have a link with an image inside, the image should have always an alt text.
The title attribute of the link will be ignored from the screen-reader.
