### PR TITLE
Fix failing tests.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix failing tests (caused by https://github.com/4teamwork/ftw.slider/pull/60).
+  [mbaechtold]
 
 
 1.0.0a1 (2015-12-04)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ maintainer = 'Mathias Leimgruber'
 tests_require = [
     'ftw.builder',
     'ftw.testing',
+    'ftw.slider [tests]',
     'ftw.testbrowser',
     'plone.app.testing',
     'plone.testing',


### PR DESCRIPTION
This has been caused by a recent change in the dependency "ftw.slider" (https://github.com/4teamwork/ftw.slider/pull/60).
