### PR TITLE
Remove workflow from ftw.slider.Pane

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove workflow from ftw.slider.Pane
+  [raphael-s]
 
 
 1.0.1 (2016-08-09)

--- a/ftw/sliderblock/profiles/default/workflows.xml
+++ b/ftw/sliderblock/profiles/default/workflows.xml
@@ -2,5 +2,6 @@
 <object name="portal_workflow" meta_type="Plone Workflow Tool">
     <bindings>
         <type type_id="ftw.sliderblock.SliderBlock"/>
+        <type type_id="ftw.slider.Pane"/>
     </bindings>
 </object>


### PR DESCRIPTION
Removes the workflow from ftw.slider.Pane because slider images should never have a workflow on them.
