### PR TITLE
Crop slider images... or not.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add checkbox to choose if the image should be cropped or not.
+  [mathias.leimgruber]
 
 
 1.1.0 (2016-10-25)

--- a/ftw/sliderblock/browser/templates/sliderblock.pt
+++ b/ftw/sliderblock/browser/templates/sliderblock.pt
@@ -7,6 +7,7 @@
         tal:condition="here/show_title | python: True" />
 
     <tal:slider define="panes view/panes;
+                        direction python: context.crop_image and 'down' or 'up';
                         portal context/@@plone_portal_state/portal;">
 
         <div tal:condition="python: view.can_add() and not panes"
@@ -32,7 +33,7 @@
                                  tal:define="images pane/@@images">
 
                                  <img tal:define="scales pane/@@images;
-                                                  thumbnail python: scales.scale('image', scale='sliderblock', direction='down');"
+                                                  thumbnail python: scales.scale('image', scale='sliderblock', direction=direction);"
                                        tal:attributes="src thumbnail/url;
                                                        width thumbnail/width;
                                                        height thumbnail/height;

--- a/ftw/sliderblock/contents/sliderblock.py
+++ b/ftw/sliderblock/contents/sliderblock.py
@@ -28,6 +28,16 @@ class ISliderBlockSchema(form.Schema):
         required=False,
     )
 
+    crop_image = schema.Bool(
+        title=_(u'sliderblock_crop_image_label',
+                default=u'Crop and scale images'),
+        description=_(u'help_text_crop_image',
+                      default=u'Crop and scale images to a predefined ratio'),
+        default=True,
+        required=False,
+        missing_value=True
+    )
+
     slick_config = schema.Text(
         title=_(u'sliderblock_slick_config_label', default=u'Configuration'),
         description=_(u'sliderblock_slick_config_description',

--- a/ftw/sliderblock/locales/de/LC_MESSAGES/ftw.sliderblock.po
+++ b/ftw/sliderblock/locales/de/LC_MESSAGES/ftw.sliderblock.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-28 07:20+0000\n"
+"POT-Creation-Date: 2016-12-07 15:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,42 +14,63 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/sliderblock/browser/templates/sliderblock.pt:23
+msgid "Edit image directly"
+msgstr "Bild direkt bearbeiten"
+
 #: ./ftw/sliderblock/profiles/default/types/ftw.sliderblock.SliderBlock.xml
 msgid "SliderBlock"
 msgstr "Bilderkarussell"
+
+#: ./ftw/sliderblock/configure.zcml:22
+msgid "SliderBlock for use with ftw.simplelayout"
+msgstr ""
 
 #: ./ftw/sliderblock/profiles/default/types/ftw.sliderblock.SliderBlock.xml
 msgid "The slider block renders an image carousel. The images shown in the carousel may link to internal or external URLs."
 msgstr "Das Bilderkarussell zeigte eine rotierende Bildergalerie an. Die angezeigten Bilder können auf interne oder externe URLs verlinken."
 
 #. Default: "This SliderBlock is empty. Please add some SliderPanes through ${folder_contents_url}."
-#: ./ftw/sliderblock/browser/templates/sliderblock.pt:14
+#: ./ftw/sliderblock/browser/templates/sliderblock.pt:15
 msgid "empty_sliderblock_label"
 msgstr "Dieser SliderBlock ist leer. Bitte fügen Sie Bilder hinzu via <a href=\"${folder_contents_url}\">Inhalte</a>."
 
+#: ./ftw/sliderblock/configure.zcml:22
+msgid "ftw.sliderblock default"
+msgstr ""
+
+#. Default: "Crop and scale images to a predefined ratio"
+#: ./ftw/sliderblock/contents/sliderblock.py:34
+msgid "help_text_crop_image"
+msgstr "Bilder werden auf ein hinterlegtes Verhältnis zugeschnitten (Standardmässig im Verhältnis 3 zu 2). Falls deaktiviert werden die Bilder nicht mehr zugeschnitten. Vorteil falls aktiviert, alle Bilder sind immer gleich gross."
+
 #. Default: "Show folder contents"
-#: ./ftw/sliderblock/contents/sliderblock.py:56
+#: ./ftw/sliderblock/contents/sliderblock.py:75
 msgid "label_show_folder_contents"
 msgstr "Inhalte anzeigen"
 
+#. Default: "Crop and scale images"
+#: ./ftw/sliderblock/contents/sliderblock.py:32
+msgid "sliderblock_crop_image_label"
+msgstr "Bilder zuschneiden"
+
 #. Default: "Show title"
-#: ./ftw/sliderblock/contents/sliderblock.py:25
+#: ./ftw/sliderblock/contents/sliderblock.py:26
 msgid "sliderblock_show_title_label"
 msgstr "Titel anzeigen"
 
 #. Default: "See http://kenwheeler.github.io/slick/"
-#: ./ftw/sliderblock/contents/sliderblock.py:32
+#: ./ftw/sliderblock/contents/sliderblock.py:43
 msgid "sliderblock_slick_config_description"
 msgstr "Siehe http://kenwheeler.github.io/slick/"
 
 #. Default: "Configuration"
-#: ./ftw/sliderblock/contents/sliderblock.py:31
+#: ./ftw/sliderblock/contents/sliderblock.py:42
 msgid "sliderblock_slick_config_label"
 msgstr "Konfiguration"
 
 #. Default: "Title"
-#: ./ftw/sliderblock/contents/sliderblock.py:20
+#: ./ftw/sliderblock/contents/sliderblock.py:21
 msgid "sliderblock_title_label"
 msgstr "Titel"
-
 

--- a/ftw/sliderblock/locales/en/LC_MESSAGES/ftw.sliderblock.po
+++ b/ftw/sliderblock/locales/en/LC_MESSAGES/ftw.sliderblock.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-28 07:20+0000\n"
+"POT-Creation-Date: 2016-12-07 15:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,8 +14,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/sliderblock/browser/templates/sliderblock.pt:23
+msgid "Edit image directly"
+msgstr ""
+
 #: ./ftw/sliderblock/profiles/default/types/ftw.sliderblock.SliderBlock.xml
 msgid "SliderBlock"
+msgstr ""
+
+#: ./ftw/sliderblock/configure.zcml:22
+msgid "SliderBlock for use with ftw.simplelayout"
 msgstr ""
 
 #: ./ftw/sliderblock/profiles/default/types/ftw.sliderblock.SliderBlock.xml
@@ -23,33 +31,46 @@ msgid "The slider block renders an image carousel. The images shown in the carou
 msgstr ""
 
 #. Default: "This SliderBlock is empty. Please add some SliderPanes through ${folder_contents_url}."
-#: ./ftw/sliderblock/browser/templates/sliderblock.pt:14
+#: ./ftw/sliderblock/browser/templates/sliderblock.pt:15
 msgid "empty_sliderblock_label"
 msgstr "This SliderBlock is empty. Please add some SliderPanes through <a href=\"${folder_contents_url}\">folder contents</a>."
 
+#: ./ftw/sliderblock/configure.zcml:22
+msgid "ftw.sliderblock default"
+msgstr ""
+
+#. Default: "Crop and scale images to a predefined ratio"
+#: ./ftw/sliderblock/contents/sliderblock.py:34
+msgid "help_text_crop_image"
+msgstr ""
+
 #. Default: "Show folder contents"
-#: ./ftw/sliderblock/contents/sliderblock.py:56
+#: ./ftw/sliderblock/contents/sliderblock.py:75
 msgid "label_show_folder_contents"
 msgstr ""
 
+#. Default: "Crop and scale images"
+#: ./ftw/sliderblock/contents/sliderblock.py:32
+msgid "sliderblock_crop_image_label"
+msgstr ""
+
 #. Default: "Show title"
-#: ./ftw/sliderblock/contents/sliderblock.py:25
+#: ./ftw/sliderblock/contents/sliderblock.py:26
 msgid "sliderblock_show_title_label"
 msgstr ""
 
 #. Default: "See http://kenwheeler.github.io/slick/"
-#: ./ftw/sliderblock/contents/sliderblock.py:32
+#: ./ftw/sliderblock/contents/sliderblock.py:43
 msgid "sliderblock_slick_config_description"
 msgstr ""
 
 #. Default: "Configuration"
-#: ./ftw/sliderblock/contents/sliderblock.py:31
+#: ./ftw/sliderblock/contents/sliderblock.py:42
 msgid "sliderblock_slick_config_label"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/sliderblock/contents/sliderblock.py:20
+#: ./ftw/sliderblock/contents/sliderblock.py:21
 msgid "sliderblock_title_label"
 msgstr ""
-
 

--- a/ftw/sliderblock/locales/ftw.sliderblock.pot
+++ b/ftw/sliderblock/locales/ftw.sliderblock.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-28 07:20+0000\n"
+"POT-Creation-Date: 2016-12-07 15:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,8 +14,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/sliderblock/browser/templates/sliderblock.pt:23
+msgid "Edit image directly"
+msgstr ""
+
 #: ./ftw/sliderblock/profiles/default/types/ftw.sliderblock.SliderBlock.xml
 msgid "SliderBlock"
+msgstr ""
+
+#: ./ftw/sliderblock/configure.zcml:22
+msgid "SliderBlock for use with ftw.simplelayout"
 msgstr ""
 
 #: ./ftw/sliderblock/profiles/default/types/ftw.sliderblock.SliderBlock.xml
@@ -23,33 +31,46 @@ msgid "The slider block renders an image carousel. The images shown in the carou
 msgstr ""
 
 #. Default: "This SliderBlock is empty. Please add some SliderPanes through ${folder_contents_url}."
-#: ./ftw/sliderblock/browser/templates/sliderblock.pt:14
+#: ./ftw/sliderblock/browser/templates/sliderblock.pt:15
 msgid "empty_sliderblock_label"
 msgstr ""
 
+#: ./ftw/sliderblock/configure.zcml:22
+msgid "ftw.sliderblock default"
+msgstr ""
+
+#. Default: "Crop and scale images to a predefined ratio"
+#: ./ftw/sliderblock/contents/sliderblock.py:34
+msgid "help_text_crop_image"
+msgstr ""
+
 #. Default: "Show folder contents"
-#: ./ftw/sliderblock/contents/sliderblock.py:56
+#: ./ftw/sliderblock/contents/sliderblock.py:75
 msgid "label_show_folder_contents"
 msgstr ""
 
+#. Default: "Crop and scale images"
+#: ./ftw/sliderblock/contents/sliderblock.py:32
+msgid "sliderblock_crop_image_label"
+msgstr ""
+
 #. Default: "Show title"
-#: ./ftw/sliderblock/contents/sliderblock.py:25
+#: ./ftw/sliderblock/contents/sliderblock.py:26
 msgid "sliderblock_show_title_label"
 msgstr ""
 
 #. Default: "See http://kenwheeler.github.io/slick/"
-#: ./ftw/sliderblock/contents/sliderblock.py:32
+#: ./ftw/sliderblock/contents/sliderblock.py:43
 msgid "sliderblock_slick_config_description"
 msgstr ""
 
 #. Default: "Configuration"
-#: ./ftw/sliderblock/contents/sliderblock.py:31
+#: ./ftw/sliderblock/contents/sliderblock.py:42
 msgid "sliderblock_slick_config_label"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/sliderblock/contents/sliderblock.py:20
+#: ./ftw/sliderblock/contents/sliderblock.py:21
 msgid "sliderblock_title_label"
 msgstr ""
-
 

--- a/ftw/sliderblock/tests/test_sliderblock_view.py
+++ b/ftw/sliderblock/tests/test_sliderblock_view.py
@@ -92,3 +92,11 @@ class TestSliderBlockRendering(TestCase):
         self.assertEqual(
             '{}',
             browser.css('.sl-block-content div').first.attrib['data-settings'])
+
+    @browsing
+    def test_images_are_cropped_by_default(self, browser):
+        browser.login().visit(self.block, view='@@block_view')
+
+        img = browser.css('.sliderPane img').first
+        self.assertEquals('1200', img.attrib['width'])
+        self.assertEquals('800', img.attrib['height'])

--- a/ftw/sliderblock/tests/test_sliderblock_view.py
+++ b/ftw/sliderblock/tests/test_sliderblock_view.py
@@ -6,6 +6,7 @@ from ftw.testbrowser import browsing
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
+import transaction
 
 
 class TestSliderBlockRendering(TestCase):
@@ -94,9 +95,19 @@ class TestSliderBlockRendering(TestCase):
             browser.css('.sl-block-content div').first.attrib['data-settings'])
 
     @browsing
-    def test_images_are_cropped_by_default(self, browser):
+    def test_images_are_cropped_and_down_scaled_by_default(self, browser):
         browser.login().visit(self.block, view='@@block_view')
 
         img = browser.css('.sliderPane img').first
         self.assertEquals('1200', img.attrib['width'])
+        self.assertEquals('800', img.attrib['height'])
+
+    @browsing
+    def test_images_are_not_cropped_and_upscaled_option(self, browser):
+        self.block.crop_image = False
+        transaction.commit()
+        browser.login().visit(self.block, view='@@block_view')
+
+        img = browser.css('.sliderPane img').first
+        self.assertEquals('800', img.attrib['width'])
         self.assertEquals('800', img.attrib['height'])


### PR DESCRIPTION
The default behavior changed with 1.1.0. But in some cases we want the old behavior back.