### PR TITLE
Add support to render the title independently of the text.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- New option on the slider pane allows to render the title of the pane
+  without the need of adding a slider pane text. Until now the title was only
+  rendered when the pane had some text (requires at least ftw.slider 3.1.0).
+  [mbaechtold]
 
 
 1.2.0 (2016-12-07)

--- a/ftw/sliderblock/browser/templates/sliderblock.pt
+++ b/ftw/sliderblock/browser/templates/sliderblock.pt
@@ -40,11 +40,12 @@
                                                        alt pane/Description"/>
                             </div>
                             <div class="sliderText"
-                                 tal:condition="pane/text">
-                                <p tal:condition="pane/title"
+                                 tal:condition="python: pane.show_title or pane.text">
+                                <p tal:condition="pane/show_title"
                                    tal:content="pane/title"
                                    tal:attributes="class python: 'documentFirstHeading title external-link' if pane.external_url else 'documentFirstHeading title'"/>
-                                <span tal:replace="structure pane/text/output"/>
+                                <span tal:condition="pane/text"
+                                      tal:replace="structure pane/text/output"/>
                             </div>
                         </a>
                       </tal:pane>

--- a/ftw/sliderblock/tests/__init__.py
+++ b/ftw/sliderblock/tests/__init__.py
@@ -1,0 +1,17 @@
+from ftw.sliderblock.testing import FTW_SLIDERBLOCK_FUNCTIONAL_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+import transaction
+
+
+class FunctionalTestCase(TestCase):
+    layer = FTW_SLIDERBLOCK_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+    def grant(self, *roles):
+        setRoles(self.portal, TEST_USER_ID, list(roles))
+        transaction.commit()

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
 
     install_requires=[
         'ftw.simplelayout [contenttypes] >= 1.12.0',
-        'ftw.slider >= 3.0.0',
+        'ftw.slider >= 3.1.0',
         'setuptools',
         'plone.dexterity',
         'plone.app.dexterity',


### PR DESCRIPTION
A new option on the slider pane (introduced in "ftw.slider" 3.1.0) allows to render the title of the pane without the need of adding a slider pane text. Until now the title was only rendered when the pane had some text.

See https://github.com/4teamwork/ftw.slider/pull/71 for the implementation in "ftw.slider".