### PR TITLE
Make SliderBlock addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make SliderBlock addable on plone site per default [raphael-s]
 
 
 1.3.1 (2017-01-17)

--- a/ftw/sliderblock/profiles/default/types/Plone_Site.xml
+++ b/ftw/sliderblock/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.sliderblock.SliderBlock" />
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.sliderblock` is installed the SliderBlock can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle the SliderBlock.