### PR TITLE
Add data-index attr to buttons of dot template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add data-index attr to buttons of dot template. [mathias.leimgruber]
 
 
 2.0.1 (2019-05-10)

--- a/ftw/sliderblock/browser/resources/sliderblock.js
+++ b/ftw/sliderblock/browser/resources/sliderblock.js
@@ -11,7 +11,7 @@
         var title = $(slider.$slides[index]).find('.title').text();
         var alttext = $(slider.$slides[index]).find('.sliderImage img').attr('alt');
         var buttonText = title || alttext || index;
-        var button = $('<button type="button" />').text(buttonText);
+        var button = $('<button type="button" data-index="' + (index + 1) + '" />').text(buttonText);
         return button[0].outerHTML
       },
 


### PR DESCRIPTION
Purpose: This way we can access the number again. This is required by some customers. 

Example: 
``` 
    selector:before{
        content: attr(data-index);
    }
```